### PR TITLE
Change grunt serve to npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The workshop is run as a series of slide decks. The decks are written in HTML, a
 
 ```
 npm install
-grunt serve
+npm start 
 ```
 
 This should run an http server locally and spawn a browser window with the first slide of the workshop. Check out the [reveal.js documentation](https://github.com/hakimel/reveal.js) for more on using reveal.js.


### PR DESCRIPTION
Using grunt serve to run the slides locally assumes you already have grunt in your path, which you don't unless you install grunt globally with npm install grunt -g. 

However you can run npm start because the package json has specified the start command to be grunt serve, and grunt is one of the specified dependencies. This means you don't have to install grunt globally and shouldn't have any issues with version mismatches.